### PR TITLE
Approved pet cant delete

### DIFF
--- a/app/controllers/pets_controller.rb
+++ b/app/controllers/pets_controller.rb
@@ -41,11 +41,18 @@ class PetsController < ApplicationController
   end
 
   def destroy
-    Pet.destroy(params[:id])
-    unless session[:favorite_pets].nil?
-      session[:favorite_pets].delete(params[:id])
+    pet = Pet.find(params[:id])
+    if pet.adoptable?
+      ApplicationPet.where(pet_id: pet.id).destroy_all
+      Pet.destroy(pet.id)
+      unless session[:favorite_pets].nil?
+        session[:favorite_pets].delete(params[:id])
+      end
+      redirect_to '/pets'
+    else
+      flash[:notice] = "Pet #{pet.name} cannot be deleted: pet is pending adoption"
+      redirect_to "/pets/#{pet.id}"
     end
-    redirect_to '/pets'
   end
 
   private

--- a/spec/features/pets/destroy_spec.rb
+++ b/spec/features/pets/destroy_spec.rb
@@ -19,6 +19,40 @@ RSpec.describe 'delete pet page', type: :feature do
     click_on 'Delete Pet'
 
     expect(current_path).to eq("/pets")
-    # expect(page).to_not have_content(pet.id)
+    expect(page).to_not have_content(pet.id)
+  end
+  it 'cannot delete a pet with an approved application' do
+    shelter = Shelter.create(name: 'Old Dog Haven',
+                               address: '166 Main St',
+                               city: 'Denver',
+                               state: 'CO',
+                               zip: '80208')
+
+    pet = Pet.create(image: 'https://i.ytimg.com/vi/2xZsXlSj-ts/maxresdefault.jpg',
+                     name: 'Maggie',
+                     description: 'A thoughtful sentient being',
+                     age: '2 years',
+                     sex: 'female',
+                     shelter: shelter)
+    application = Application.create(name: 'Gabby',
+                                     address: "24 Silver Street",
+                                     city: "Springfield",
+                                     state: "MA",
+                                     zip: "01108",
+                                     phone_number: "555-8987",
+                                     description: "I'm a clown who needs a sidekick.")
+    ApplicationPet.create(pet: pet, application: application)
+
+    visit "/applications/#{application.id}"
+
+    expect(page).to have_content("Approve Application for #{pet.name}")
+
+    click_on "Approve Application for #{pet.name}"
+
+    visit "/pets/#{pet.id}"
+
+    click_on "Delete Pet"
+
+    expect(page).to have_content("Pet #{pet.name} cannot be deleted: pet is pending adoption")
   end
 end

--- a/spec/features/pets/show_spec.rb
+++ b/spec/features/pets/show_spec.rb
@@ -23,4 +23,5 @@ RSpec.describe 'pet id page', type: :feature do
     expect(page).to have_content("#{pet.sex}")
     expect(page).to have_content("adoptable")
   end
+  
 end

--- a/spec/features/shelters/show_spec.rb
+++ b/spec/features/shelters/show_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe "shelter id page", type: :feature do
     ApplicationPet.create(pet: pet_3, application: application_2)
     visit "/shelters/#{shelter.id}"
 
-    expect(page).to have_content("Total number of pets in shelter: 3")
+    expect(page).to have_content("Total Number of Pets: 3")
     expect(page).to have_content("Average Rating: 4")
     expect(page).to have_content("Number of Applications: 2")
   end


### PR DESCRIPTION
Hi @sciencefixion,

Now when a user tries to delete a pet that is pending adoption, they receive a flash message alerting them them that the pet cannot be deleted.

If a user revokes an application for a pet, and goes to delete the pet, then that instance of `ApplicationPet` is deleted and the pet can be deleted.