### PR TITLE
Add links to favs index and application show page

### DIFF
--- a/app/controllers/pets_controller.rb
+++ b/app/controllers/pets_controller.rb
@@ -32,6 +32,7 @@ class PetsController < ApplicationController
     if @favorites.nil? || @favorites.keys.include?(@pet.id.to_s) == false
       @link_title = "Add Pet to Favorites"
       @link_method = :patch
+      # redirect_to "/pets/#{@pet.id}"
     else
       @link_title = "Remove Pet from Favorites"
       @link_method = :delete

--- a/app/views/applications/show.html.erb
+++ b/app/views/applications/show.html.erb
@@ -8,6 +8,7 @@
 <p><%= @application.description %></p>
 
 <% @pets.each do |pet| %>
+  <%= link_to "#{pet.name}'s Information", "/pets/#{pet.id}" %>
   <% if pet.adoptable? %>
     <p><%= link_to "Approve Application for #{pet.name}", "/applicationpets/#{pet.id}", method: :patch %></p>
   <% else %>

--- a/app/views/favorites/index.html.erb
+++ b/app/views/favorites/index.html.erb
@@ -8,6 +8,7 @@
   <div class="pet">
     <% pet = Pet.find(favorite_id) %>
     <img src=<%= pet.image %> alt=<%= pet.name %></img>
+    <%= link_to "Remove #{pet.name} from Favorites", "/favorites/#{pet.id}", method: :delete %>
     <h3><a href="/pets/<%= pet.id %>/"><%= pet.name %></a></h3>
   </div>
   <% end %>

--- a/spec/features/applications/list_of_pets_spec.rb
+++ b/spec/features/applications/list_of_pets_spec.rb
@@ -23,13 +23,16 @@ RSpec.describe "New Applications page" do
 
   it 'can apply to adopt pets from the favorites list' do
     visit '/pets'
+
     click_on "Maggie"
     click_on "Add Pet to Favorites"
+
+    visit '/pets'
+
     click_on "Shaggie"
     click_on "Add Pet to Favorites"
 
     visit '/favorites'
-
     click_on "Apply to Adopt Pet(s)"
 
     check("pet_ids[]", match: :first)

--- a/spec/features/applications/show_spec.rb
+++ b/spec/features/applications/show_spec.rb
@@ -41,6 +41,8 @@ RSpec.describe 'Application show page', type: :feature do
     expect(page).to have_content("#{@application.state}")
     expect(page).to have_content("#{@application.zip}")
     expect(page).to have_content("#{@application.phone_number}")
+    expect(page).to have_content("#{@pet_1.name}'s Information")
+
   end
   it 'can approve an application for a pet' do
     visit "/applications/#{@application.id}"

--- a/spec/features/favorites/index_spec.rb
+++ b/spec/features/favorites/index_spec.rb
@@ -25,14 +25,22 @@ RSpec.describe "Favorites index page" do
 
     click_on "Maggie"
     click_on "Add Pet to Favorites"
+    # expect(current_path).to eq("/pets/#{@pet_1.id}")
+
+    visit '/pets'
 
     click_on "Shaggie"
     click_on "Add Pet to Favorites"
+    # expect(current_path).to eq("/pets/#{@pet_2.id}")
 
     visit '/favorites'
 
     expect(page).to have_content(@pet_1.name)
+    expect(page).to have_link("Remove #{@pet_1.name} from Favorites")
+
     expect(page).to have_content(@pet_2.name)
+    expect(page).to have_link("Remove #{@pet_1.name} from Favorites")
+
 
   end
   it "shows text saying No Favorites if favorties is empty" do
@@ -46,6 +54,8 @@ RSpec.describe "Favorites index page" do
     click_on "Maggie"
     click_on "Add Pet to Favorites"
 
+    visit '/pets'
+
     click_on "Shaggie"
     click_on "Add Pet to Favorites"
 
@@ -55,7 +65,6 @@ RSpec.describe "Favorites index page" do
     click_on "Remove All Favorited Pets"
 
     expect(current_path).to eq("/favorites")
-    # save_and_open_page
     expect(page).to have_content("You have no favorited pets.")
     expect(page).to have_content("Favorite Pets: 0")
   end


### PR DESCRIPTION
This resolves two issues with links not appearing on pages where they should.

1. In the favorites index, there should now be a link to remove each pet from favorites under their profile photo.
2. The application show page should now have links to pet's show pages.